### PR TITLE
To fix compiler error of uuid.NewV1() in single context.

### DIFF
--- a/server.go
+++ b/server.go
@@ -100,11 +100,12 @@ func (h authHandler) isAuthed(sid string) bool {
 }
 
 func (h authHandler) newSession() string {
-	sid := uuid.NewV1().String()
+	sid,_ := uuid.NewV1()
+	sid2String := sid.String()
 	h.Lock()
-	h.sessions[sid] = nada
+	h.sessions[sid2String] = nada
 	h.Unlock()
-	return sid
+	return sid2String
 }
 
 func (h authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
[Why] Cause uuid.NewV1 would return multiple-value.
[How] Return the correct value.